### PR TITLE
Update guild features & domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ e.g.: https://discord.com/api/invite/discord-townhall - the guild's features are
 
 * `PARTNERED` - Partner badge near the server name and in mutual server lists. 
 
-* `PREVIEW_ENABLED` - Enables [lurking](https://discord.com/developers/docs/game-and-server-management/special-channels#lurker-mode) via discovery and invites while logged out, as well as from crossposted announcements from news channels. 
+* `PREVIEW_ENABLED` - Allows a user to view the server without passing membership gating.
 
 * `PRIVATE_THREADS` — Ability to create private threads
 

--- a/README.md
+++ b/README.md
@@ -59,9 +59,10 @@ e.g.: https://discord.com/api/invite/discord-townhall - the guild's features are
 * `MEMBER_VERIFICATION_GATE_ENABLED` - Has member verification gate enabled, requiring new users to pass the verification gate before interacting with the server.
 
 * `MONETIZATION_ENABLED` — Allows the server to set a team in dev portal to cash out ticketed stage payouts
+
 * `MORE_EMOJI` - Adds 150 extra emoji slots to each category (normal and animated emoji). Not used in server boosting.
 
-* `MORE_STICKERS` — Adds 60 sticker slots no matter how many it had before. Not used in server boosting.
+* `MORE_STICKERS` — Adds 60 total sticker slots no matter how many it had before. Not used in server boosting.
 
 * `NEW_THREAD_PERMISSIONS` — Guild has [new thread permissions](https://support.discord.com/hc/en-us/articles/4403205878423-Threads-FAQ#h_01FDGC4JW2D665Y230KPKWQZPN).
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ e.g.: https://discord.com/api/invite/discord-townhall - the guild's features are
 
 * `HUB` — [Hubs](https://dis.gd/studenthubs) contain a directory channel that let you find school-related, student-run servers for your school or university.
 
-* ~~`LURKABLE`~~ - Deprecated in favor of `PREVIEW_ENABLED`
+* ~~`LURKABLE`~~ - Deprecated
 
 * `INVITE_SPLASH` - Ability to set a background image that will display on all invite links.
 
@@ -58,11 +58,10 @@ e.g.: https://discord.com/api/invite/discord-townhall - the guild's features are
 
 * `MEMBER_VERIFICATION_GATE_ENABLED` - Has member verification gate enabled, requiring new users to pass the verification gate before interacting with the server.
 
-* `MONETIZATION_ENABLED` — Has ticketed stages enabled.
-
+* `MONETIZATION_ENABLED` — Allows the server to set a team in dev portal to cash out ticketed stage payouts
 * `MORE_EMOJI` - Adds 150 extra emoji slots to each category (normal and animated emoji). Not used in server boosting.
 
-* `MORE_STICKERS` — Guild has 60 sticker slots no matter how many it had before. Not used in server boosting.
+* `MORE_STICKERS` — Adds 60 sticker slots no matter how many it had before. Not used in server boosting.
 
 * `NEW_THREAD_PERMISSIONS` — Guild has [new thread permissions](https://support.discord.com/hc/en-us/articles/4403205878423-Threads-FAQ#h_01FDGC4JW2D665Y230KPKWQZPN).
 

--- a/domains.md
+++ b/domains.md
@@ -18,6 +18,7 @@
 | discordmerch.com      | Merch store                              |
 | discordpartygames.com | Voice channel activity API host          |
 | discord-activities.com| Voice channel activity API host          |
+| discord-activities.com| Voice channel activity data management   |
 | discordsays.com       | Voice channel activity host              |
 | discordstatus.com     | Status page                              |
 

--- a/domains.md
+++ b/domains.md
@@ -18,7 +18,7 @@
 | discordmerch.com      | Merch store                              |
 | discordpartygames.com | Voice channel activity API host          |
 | discord-activities.com| Voice channel activity API host          |
-| discord-activities.com| Voice channel activity data management   |
+| discordactivities.com | Voice channel activity data management   |
 | discordsays.com       | Voice channel activity host              |
 | discordstatus.com     | Status page                              |
 


### PR DESCRIPTION
* Updated the description for the `LURKABLE` & `PREVIEW_ENABLED` guild features. The `PREVIEW_ENABLED` serves a completely different purpose. It's for membership gating and allows a user to view the server while being a member of it (without passing membership gating). The `LURKABLE` feature allowed a user to view the server without being a member of the server.
* Updated the description for the `MORE_STICKERS` guild feature to maintain consistency with the `MORE_EMOI` guild feature
* Updated the description for the `MONETIZATION_ENABLED` guild feature
* Adds the https://discordactivities.com domain (from https://support.discord.com/hc/en-us/articles/4404366703255-Discord-Chess-in-the-Park-FAQ)