### PR TITLE
Add `PREMIUM_TIER_3_OVERRIDE` feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ e.g.: https://discord.com/api/invite/discord-townhall - the guild's features are
 
 * `WELCOME_SCREEN_ENABLED` - Has welcome screen enabled, a modal shown to new joiners that features different channels, and a short description of the guild.
 
-* `PREMIUM_TIER_3_OVERRIDE` - Forces the server to server boosting level 3 (specifically created by Jethro for their personal server)
+* `PREMIUM_TIER_3_OVERRIDE` - Forces the server to server boosting level 3 (specifically created by Discord Staff Member "Jethro" for their personal server)
 
 ----
 

--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ e.g.: https://discord.com/api/invite/discord-townhall - the guild's features are
 
 * `WELCOME_SCREEN_ENABLED` - Has welcome screen enabled, a modal shown to new joiners that features different channels, and a short description of the guild.
 
+* `PREMIUM_TIER_3_OVERRIDE` - Forces the server to server boosting level 3 (specifically created by Jethro for their personal server)
+
 ----
 
 #### Community program feature comparison 


### PR DESCRIPTION
This feature seems to be only in use on Jethro's personal server which can be confirmed here: https://discord.com/api/invite/jethro
![image](https://user-images.githubusercontent.com/17235016/133159081-ebb25eb4-f71a-45d2-a000-94c95fc7976d.png)

It does what the name may suggest: Force the server to server boost level 3 no matter how many boosts the server has:
![image](https://user-images.githubusercontent.com/17235016/133159272-f3062653-8c69-4778-8e18-078b73941a99.png)

It was also confirmed that it was supposedly only created solely for their personal server:
![image](https://user-images.githubusercontent.com/17235016/133159401-3963ac47-a376-4fd1-9e1c-ed2cd24c636f.png)
