### PR TITLE
Update partners.txt

### DIFF
--- a/partners.txt
+++ b/partners.txt
@@ -2187,7 +2187,6 @@ discord.gg/shikigamixo
 discord.gg/shinysaffichu
 discord.gg/shironamie
 discord.gg/shoptitans
-discord.gg/shot
 discord.gg/shotgunfarmers
 discord.gg/shugi
 discord.gg/shul


### PR DESCRIPTION
removed discord.gg/shot since it is no longer partnered with discord.