### PR TITLE
Update some links in shortlinks.txt

### DIFF
--- a/shortlinks.txt
+++ b/shortlinks.txt
@@ -129,8 +129,6 @@ dis.gd/google
 dis.gd/googleplaystoreintegration
 dis.gd/guidelines
 dis.gd/gwupdate
-dis.gd/hackweek
-dis.gd/hackweekwinners
 dis.gd/hackedaccount
 dis.gd/halloweenbot
 dis.gd/halloweenbot2020

--- a/shortlinks.txt
+++ b/shortlinks.txt
@@ -281,6 +281,7 @@ dis.gd/teamchaos
 dis.gd/templates
 dis.gd/terms
 dis.gd/testflight
+dis.gd/text-in-voice
 dis.gd/thinknoodlesbadnorth
 dis.gd/thinknoodlesfk
 dis.gd/thnxcya

--- a/shortlinks.txt
+++ b/shortlinks.txt
@@ -219,9 +219,7 @@ dis.gd/password
 dis.gd/pipepunkyt-lastyear
 dis.gd/pixelatedapollo
 dis.gd/police2tw
-dis.gd/pride2021
 dis.gd/pride2021-donate
-dis.gd/prideshowcase
 dis.gd/pronoun-bot
 dis.gd/protectdata
 dis.gd/publicguidelines

--- a/shortlinks.txt
+++ b/shortlinks.txt
@@ -35,6 +35,7 @@ dis.gd/buildyourkingdom
 dis.gd/childsplaydiscordhype
 dis.gd/classroom
 dis.gd/cohhcarnage
+dis.gd/common-scams
 dis.gd/communityprograms
 dis.gd/communityservers
 dis.gd/communitystories

--- a/shortlinks.txt
+++ b/shortlinks.txt
@@ -6,6 +6,7 @@ dis.gd/alphaking
 dis.gd/alpharad-koth
 dis.gd/androidboogie
 dis.gd/appdiscoveryblog
+dis.gd/appeal
 dis.gd/apps
 dis.gd/ar12
 dis.gd/atsundowntw

--- a/shortlinks.txt
+++ b/shortlinks.txt
@@ -277,6 +277,7 @@ dis.gd/tcabu2
 dis.gd/teamchaos
 dis.gd/templates
 dis.gd/terms
+dis.gd/testclients
 dis.gd/testflight
 dis.gd/text-in-voice
 dis.gd/thinknoodlesbadnorth

--- a/shortlinks.txt
+++ b/shortlinks.txt
@@ -220,6 +220,7 @@ dis.gd/pipepunkyt-lastyear
 dis.gd/pixelatedapollo
 dis.gd/police2tw
 dis.gd/pride2021-donate
+dis.gd/pride-2022
 dis.gd/pronoun-bot
 dis.gd/protectdata
 dis.gd/publicguidelines

--- a/shortlinks.txt
+++ b/shortlinks.txt
@@ -268,6 +268,7 @@ dis.gd/streamkit
 dis.gd/studenthubs
 dis.gd/subnauticatw
 dis.gd/sunlightbladesinner
+dis.gd/supersafeaccount
 dis.gd/support
 dis.gd/swag
 dis.gd/swaggersouls-lastyear

--- a/shortlinks.txt
+++ b/shortlinks.txt
@@ -131,6 +131,7 @@ dis.gd/guidelines
 dis.gd/gwupdate
 dis.gd/hackweek
 dis.gd/hackweekwinners
+dis.gd/hackedaccount
 dis.gd/halloweenbot
 dis.gd/halloweenbot2020
 dis.gd/help


### PR DESCRIPTION
**Added**
- dis.gd/text-in-voice
- di.gd/hackedaccount
- dis.gd/testclients
- dis.gd/supersafeaccounts
- dis.gd/commonscams
- dis.gd/pride-2022
- dis.gd/appeal

**Removed**
- dis.gd/pride2021
- dis.gd/prideshowcase
- dis.gd/hackweek
- dis.gd/hackweekwinners

I'm not sure if the links I removed are correct, as they are still theoretically dis.gd links and what's missing is the blog they are redirecting to, just request a change and I'll re-add them if needed.