### PR TITLE
Add `discordsez.com` to domains

### DIFF
--- a/domains.md
+++ b/domains.md
@@ -22,6 +22,7 @@
 | discord-activities.com| Voice channel activity API host          |
 | discordactivities.com | Voice channel activity data management   |
 | discordsays.com       | Voice channel activity host              |
+| discordsez.com        | Voice channel activity staging host      |
 | discordstatus.com     | Status page                              |
 
 ## Other


### PR DESCRIPTION
Hosts a copy of the discordsays.com backend, albeit on a different cloudflare account. It was added to the public suffix list with discordsays.com.

```diff
// Discord Inc : https://discord.com
// Submitted by Sahn Lam <slam@discordapp.com>
discordsays.com
discordsez.com
```