### PR TITLE
chore(partners): remove discord.gg/sound

### DIFF
--- a/partners.txt
+++ b/partners.txt
@@ -2033,7 +2033,6 @@ discord.gg/sorey101
 discord.gg/sotfr
 discord.gg/soulboundleather
 discord.gg/soulsborne
-discord.gg/sound
 discord.gg/soup
 discord.gg/sourceengine
 discord.gg/sovitia


### PR DESCRIPTION
The server https://discord.gg/sound is no longer partnered.