### PR TITLE
Removed info about Nitro from activities

### DIFF
--- a/activities.md
+++ b/activities.md
@@ -1,101 +1,101 @@
-## ![Activities Icon](https://i.imgur.com/MoqeRCm.png) Discord Activities 
+## ![Activities Icon](https://i.imgur.com/MoqeRCm.png) Discord Activities
 ### Stable versions
-| Icon | Application ID | Application name | Nitro? | Max participants |
-|:---:|:---:| --- |:---:|:---:|
-| ![Icon](https://cdn.discordapp.com/app-icons/755600276941176913/4e0fd3bf009282c0ecd1fb010e621f28.webp?size=80) | 755600276941176913 | YouTube Together _(Deprecated. Replaced by 'Watch Together')_ |  | Unlimited |
-| ![Icon](https://cdn.discordapp.com/app-icons/755827207812677713/e594da3ca4520c7edde5b59948e97cdc.webp?size=80) | 755827207812677713 | Poker Night | ✅ | 7 |
-| ![Icon](https://cdn.discordapp.com/app-icons/773336526917861400/0227b2e89ea08d666c43003fbadbc72a.webp?size=80) | 773336526917861400 | Betrayal.io |  | Unlimited |
-| ![Icon](https://cdn.discordapp.com/app-icons/814288819477020702/0cafdebe76abfd7d8d9b015c2060512e.webp?size=80) | 814288819477020702 | Fishington.io |  | Unlimited |
-| ![Icon](https://cdn.discordapp.com/app-icons/832012774040141894/3b3981ddf67c8702920fae10b5f123ed.webp?size=80) | 832012774040141894 | Chess In The Park | ✅ | Unlimited |
-| ![Icon](https://cdn.discordapp.com/app-icons/832013003968348200/97e50fed67f44802dbb4901d74a6f9a1.webp?size=80) | 832013003968348200 | Checkers In The Park _(Formerly known as 'CG3 Prod'.)_ | ✅ | Unlimited |
-| ![Icon](https://cdn.discordapp.com/app-icons/832025144389533716/6fe6e3dda7657b83758693205a833aa1.webp?size=80) | 832025144389533716 | Blazing 8s _(Formerly known as 'Ocho' & 'CG4 Prod')_| ✅ | 8 |
-| ![Icon](https://cdn.discordapp.com/app-icons/852509694341283871/9a4a52c760994654a416740ae0b19fbb.webp?size=80) | 852509694341283871 | SpellCast | ✅ | 100 |
-| ![Icon](https://cdn.discordapp.com/app-icons/879863686565621790/0096355142a9b00bc2676ec09b9c8dbc.webp?size=80) | 879863686565621790 | Letter League _(Formerly known as 'Letter Tile')_ | ✅ | 8 |
-| ![Icon](https://cdn.discordapp.com/app-icons/880218394199220334/ec48acbad4c32efab4275cb9f3ca3a58.webp?size=80) | 880218394199220334 | Watch Together |  | Unlimited | [1^]: asd
-| ![Icon](https://cdn.discordapp.com/app-icons/902271654783242291/0fbc3e38ea4b26c47d8001eff6b94a7b.webp?size=80) | 902271654783242291 | Sketch Heads | ✅ | 8 |
-| ![Icon](https://cdn.discordapp.com/app-icons/903769130790969345/c4d8b95b8f06b1ff8cf2b769e94505a8.webp?size=80) | 903769130790969345 | Land.io | ✅ | 16 |
-| ![Icon](https://cdn.discordapp.com/app-icons/945737671223947305/12ee915c2f75d7f2c7d551819534f158.webp?size=80) | 945737671223947305 | Putt Party | ✅ | 8 |
-| ![Icon](https://cdn.discordapp.com/app-icons/947957217959759964/b485f75e95e6486a758a4aa5db3352f4.webp?size=80) | 947957217959759964 | Bobble League | ✅ | 8 |
-| ![Icon](https://cdn.discordapp.com/app-icons/950505761862189096/6f547114b2979b8bc83e4ba91b4d770d.webp?size=80) | 950505761862189096 | Know What I Meme |  | 9 |
-| ![Icon](https://cdn.discordapp.com/app-icons/976052223358406656/4f86c19a69cc3002d1b52f7a22687adf.webp?size=80) | 976052223358406656 | Ask Away | ✅ | 10 |
-| ![Icon](https://cdn.discordapp.com/app-icons/1000100849122553977/ef2be6cbe3f5b2a87c13d229cc0f8493.webp?size=80) | 1000100849122553977 | Bobble Land: Scrappies |  | 4 |
-| ![Icon](https://cdn.discordapp.com/app-icons/1006584476094177371/eace9c231b505f0c96fba27d1795c31a.webp?size=80) | 1006584476094177371 | Bash Out | ✅ | 16 |
-| ![Icon](https://cdn.discordapp.com/app-icons/1007373802981822582/7293b549efff3c5a809999d883f09202.webp?size=80) | 1007373802981822582 | Gartic Phone |  | 16 |
-| ![Icon](https://cdn.discordapp.com/app-icons/1011683823555199066/cdc044d1552ae938203583a2672a34b3.webp?size=80) | 1011683823555199066 | Krunker FRVR |  | 12 |
-| ![Icon](https://cdn.discordapp.com/app-icons/1037680572660727838/925d0f981612cc56f1f44c9be0c68be6.webp?size=80) | 1037680572660727838 | Chef Showdown | ✅ | 15 |
-| ![Icon](https://cdn.discordapp.com/app-icons/1039835161136746497/cab9ddcb00829a74c48393a9d4bff00b.webp?size=80) | 1039835161136746497 | Color Together | ✅ | 100 |
-| ![Icon](https://cdn.discordapp.com/app-icons/1070087967294631976/9a04eab3b9f50302006577b769354520.webp?size=80) | 1070087967294631976 | Jamspace |  | Unlimited |
+| Icon                                                                                                            | Application ID      | Application name                                              | Max participants |
+|-----------------------------------------------------------------------------------------------------------------|---------------------|---------------------------------------------------------------|------------------|
+| ![Icon](https://cdn.discordapp.com/app-icons/755600276941176913/4e0fd3bf009282c0ecd1fb010e621f28.webp?size=80)  | 755600276941176913  | YouTube Together _(Deprecated. Replaced by 'Watch Together')_ | Unlimited        |
+| ![Icon](https://cdn.discordapp.com/app-icons/755827207812677713/e594da3ca4520c7edde5b59948e97cdc.webp?size=80)  | 755827207812677713  | Poker Night                                                   | 7                |
+| ![Icon](https://cdn.discordapp.com/app-icons/773336526917861400/0227b2e89ea08d666c43003fbadbc72a.webp?size=80)  | 773336526917861400  | Betrayal.io                                                   | Unlimited        |
+| ![Icon](https://cdn.discordapp.com/app-icons/814288819477020702/0cafdebe76abfd7d8d9b015c2060512e.webp?size=80)  | 814288819477020702  | Fishington.io                                                 | Unlimited        |
+| ![Icon](https://cdn.discordapp.com/app-icons/832012774040141894/3b3981ddf67c8702920fae10b5f123ed.webp?size=80)  | 832012774040141894  | Chess In The Park                                             | Unlimited        |
+| ![Icon](https://cdn.discordapp.com/app-icons/832013003968348200/97e50fed67f44802dbb4901d74a6f9a1.webp?size=80)  | 832013003968348200  | Checkers In The Park _(Formerly known as 'CG3 Prod'.)_        | Unlimited        |
+| ![Icon](https://cdn.discordapp.com/app-icons/832025144389533716/6fe6e3dda7657b83758693205a833aa1.webp?size=80)  | 832025144389533716  | Blazing 8s _(Formerly known as 'Ocho' & 'CG4 Prod')_          | 8                |
+| ![Icon](https://cdn.discordapp.com/app-icons/852509694341283871/9a4a52c760994654a416740ae0b19fbb.webp?size=80)  | 852509694341283871  | SpellCast                                                     | 100              |
+| ![Icon](https://cdn.discordapp.com/app-icons/879863686565621790/0096355142a9b00bc2676ec09b9c8dbc.webp?size=80)  | 879863686565621790  | Letter League _(Formerly known as 'Letter Tile')_             | 8                |
+| ![Icon](https://cdn.discordapp.com/app-icons/880218394199220334/ec48acbad4c32efab4275cb9f3ca3a58.webp?size=80)  | 880218394199220334  | Watch Together                                                | Unlimited        |
+| ![Icon](https://cdn.discordapp.com/app-icons/902271654783242291/0fbc3e38ea4b26c47d8001eff6b94a7b.webp?size=80)  | 902271654783242291  | Sketch Heads                                                  | 8                |
+| ![Icon](https://cdn.discordapp.com/app-icons/903769130790969345/c4d8b95b8f06b1ff8cf2b769e94505a8.webp?size=80)  | 903769130790969345  | Land.io                                                       | 16               |
+| ![Icon](https://cdn.discordapp.com/app-icons/945737671223947305/12ee915c2f75d7f2c7d551819534f158.webp?size=80)  | 945737671223947305  | Putt Party                                                    | 8                |
+| ![Icon](https://cdn.discordapp.com/app-icons/947957217959759964/b485f75e95e6486a758a4aa5db3352f4.webp?size=80)  | 947957217959759964  | Bobble League                                                 | 8                |
+| ![Icon](https://cdn.discordapp.com/app-icons/950505761862189096/6f547114b2979b8bc83e4ba91b4d770d.webp?size=80)  | 950505761862189096  | Know What I Meme                                              | 9                |
+| ![Icon](https://cdn.discordapp.com/app-icons/976052223358406656/4f86c19a69cc3002d1b52f7a22687adf.webp?size=80)  | 976052223358406656  | Ask Away                                                      | 10               |
+| ![Icon](https://cdn.discordapp.com/app-icons/1000100849122553977/ef2be6cbe3f5b2a87c13d229cc0f8493.webp?size=80) | 1000100849122553977 | Bobble Land: Scrappies                                        | 4                |
+| ![Icon](https://cdn.discordapp.com/app-icons/1006584476094177371/eace9c231b505f0c96fba27d1795c31a.webp?size=80) | 1006584476094177371 | Bash Out                                                      | 16               |
+| ![Icon](https://cdn.discordapp.com/app-icons/1007373802981822582/7293b549efff3c5a809999d883f09202.webp?size=80) | 1007373802981822582 | Gartic Phone                                                  | 16               |
+| ![Icon](https://cdn.discordapp.com/app-icons/1011683823555199066/cdc044d1552ae938203583a2672a34b3.webp?size=80) | 1011683823555199066 | Krunker FRVR                                                  | 12               |
+| ![Icon](https://cdn.discordapp.com/app-icons/1037680572660727838/925d0f981612cc56f1f44c9be0c68be6.webp?size=80) | 1037680572660727838 | Chef Showdown                                                 | 15               |
+| ![Icon](https://cdn.discordapp.com/app-icons/1039835161136746497/cab9ddcb00829a74c48393a9d4bff00b.webp?size=80) | 1039835161136746497 | Color Together                                                | 100              |
+| ![Icon](https://cdn.discordapp.com/app-icons/1070087967294631976/9a04eab3b9f50302006577b769354520.webp?size=80) | 1070087967294631976 | Jamspace                                                      | Unlimited        |
 
 ### Development versions
-| Icon | Application ID | Application name | Nitro? | Max participants |
-|:---:|:---:| --- |:---:|:---:|
-| ![Icon](https://cdn.discordapp.com/app-icons/763133495793942528/3bf3592c0949620f0e76cb28ab7affd9.webp?size=80) | 763133495793942528 | PN Dev |  | 7 |
-| ![Icon](https://cdn.discordapp.com/app-icons/832012586023256104/3b3981ddf67c8702920fae10b5f123ed.webp?size=80) | 832012586023256104 | CG 2 Dev _(Also known as 'Chess In The Park Dev')_ |  | Unlimited |
-| ![Icon](https://cdn.discordapp.com/app-icons/832012682520428625/97e50fed67f44802dbb4901d74a6f9a1.webp?size=80) | 832012682520428625 | CG 3 Dev _(Also known as 'Checkers In The Park Dev')_ |  | Unlimited |
-| ![Icon](https://cdn.discordapp.com/app-icons/832013108234289153/94ccfd4c1c0749b1ccf7a52feefb0468.webp?size=80) | 832013108234289153 | CG4 Dev _(Also known as 'Blazing 8s Dev')_ |  | 8 |
-| ![Icon](https://cdn.discordapp.com/app-icons/879863753519292467/09a8b98f5f5c219e7befa6693c7f73e4.webp?size=80) | 879863753519292467 | Letter League Dev _(Formerly known as 'Letter Tile Dev')_ |  | 8 |
-| ![Icon](https://cdn.discordapp.com/app-icons/880218832743055411/3f135503dc803ce7bcf555c769b3f577.webp?size=80) | 880218832743055411 | Watch Together Dev |  | Unlimited |
-| ![Icon](https://cdn.discordapp.com/app-icons/902271746701414431/1b1a929b491a29f9c18b5001ea947c49.webp?size=80) | 902271746701414431 | Sketch Heads Dev |  | 16 |
-| ![Icon](https://cdn.discordapp.com/app-icons/910224161476083792/e69a66ab92d97173757b87ede8b02c36.webp?size=80) | 910224161476083792 | Putt Party Dev |  | 9 |
-| ![Icon](https://cdn.discordapp.com/app-icons/950507686422794280/ff823d8681b22b6c8188742a2ef761be.webp?size=80) | 950507686422794280 | Know What I Meme Dev |  | 9 |
-| ![Icon](https://cdn.discordapp.com/app-icons/1070097992746541207/9a04eab3b9f50302006577b769354520.webp?size=80) | 1070097992746541207 | Jamspace Dev |  | Unlimited |
+| Icon                                                                                                            | Application ID      | Application name                                          | Max participants |
+|-----------------------------------------------------------------------------------------------------------------|---------------------|-----------------------------------------------------------|------------------|
+| ![Icon](https://cdn.discordapp.com/app-icons/763133495793942528/3bf3592c0949620f0e76cb28ab7affd9.webp?size=80)  | 763133495793942528  | PN Dev                                                    | 7                |
+| ![Icon](https://cdn.discordapp.com/app-icons/832012586023256104/3b3981ddf67c8702920fae10b5f123ed.webp?size=80)  | 832012586023256104  | CG 2 Dev _(Also known as 'Chess In The Park Dev')_        | Unlimited        |
+| ![Icon](https://cdn.discordapp.com/app-icons/832012682520428625/97e50fed67f44802dbb4901d74a6f9a1.webp?size=80)  | 832012682520428625  | CG 3 Dev _(Also known as 'Checkers In The Park Dev')_     | Unlimited        |
+| ![Icon](https://cdn.discordapp.com/app-icons/832013108234289153/94ccfd4c1c0749b1ccf7a52feefb0468.webp?size=80)  | 832013108234289153  | CG4 Dev _(Also known as 'Blazing 8s Dev')_                | 8                |
+| ![Icon](https://cdn.discordapp.com/app-icons/879863753519292467/09a8b98f5f5c219e7befa6693c7f73e4.webp?size=80)  | 879863753519292467  | Letter League Dev _(Formerly known as 'Letter Tile Dev')_ | 8                |
+| ![Icon](https://cdn.discordapp.com/app-icons/880218832743055411/3f135503dc803ce7bcf555c769b3f577.webp?size=80)  | 880218832743055411  | Watch Together Dev                                        | Unlimited        |
+| ![Icon](https://cdn.discordapp.com/app-icons/902271746701414431/1b1a929b491a29f9c18b5001ea947c49.webp?size=80)  | 902271746701414431  | Sketch Heads Dev                                          | 16               |
+| ![Icon](https://cdn.discordapp.com/app-icons/910224161476083792/e69a66ab92d97173757b87ede8b02c36.webp?size=80)  | 910224161476083792  | Putt Party Dev                                            | 9                |
+| ![Icon](https://cdn.discordapp.com/app-icons/950507686422794280/ff823d8681b22b6c8188742a2ef761be.webp?size=80)  | 950507686422794280  | Know What I Meme Dev                                      | 9                |
+| ![Icon](https://cdn.discordapp.com/app-icons/1070097992746541207/9a04eab3b9f50302006577b769354520.webp?size=80) | 1070097992746541207 | Jamspace Dev                                              | Unlimited        |
 
 ### Staging versions
-| Icon | Application ID | Application name | Nitro? | Max participants |
-|:---:|:---:| --- |:---:|:---:|
-| ![Icon](https://cdn.discordapp.com/app-icons/763116274876022855/532775a7b8fd36fadefe18e0ebc209a0.webp?size=80) | 763116274876022855 | PN Staging |  | 7 |
-| ![Icon](https://cdn.discordapp.com/app-icons/832012730599735326/3b3981ddf67c8702920fae10b5f123ed.webp?size=80) | 832012730599735326 | CG2 Staging |  | Unlimited |
-| ![Icon](https://cdn.discordapp.com/app-icons/832012938398400562/97e50fed67f44802dbb4901d74a6f9a1.webp?size=80) | 832012938398400562 | CG3 Staging |  | Unlimited |
-| ![Icon](https://cdn.discordapp.com/app-icons/832025061657280566/832ff736821811d7f41d0ff09b374ccb.webp?size=80) | 832025061657280566 | CG4 Staging |  | 8 |
-| ![Icon](https://cdn.discordapp.com/app-icons/893449443918086174/74d41d680b96eec08562164988be671a.webp?size=80) | 893449443918086174 | SpellCast Staging |  | 100 |
-| ![Icon](https://cdn.discordapp.com/app-icons/945732077960188005/27881d08b84784b2c98a5aae921c09ae.webp?size=80) | 945732077960188005 | Putt Party Stg |  | Unlimited |
-| ![Icon](https://cdn.discordapp.com/app-icons/1049916362383962192/19afbe4b0494b686252b89856a6fe00e.webp?size=80) | 1049916362383962192 | [Deprecated] Colonist.io Staging |  | Unlimited |
-| ![Icon](https://cdn.discordapp.com/app-icons/1106787009256767498/19afbe4b0494b686252b89856a6fe00e.webp?size=80) | 1106787009256767498 | Colonist.io Staging |  | Unlimited |
+| Icon                                                                                                            | Application ID      | Application name                 | Max participants |
+|-----------------------------------------------------------------------------------------------------------------|---------------------|----------------------------------|------------------|
+| ![Icon](https://cdn.discordapp.com/app-icons/763116274876022855/532775a7b8fd36fadefe18e0ebc209a0.webp?size=80)  | 763116274876022855  | PN Staging                       | 7                |
+| ![Icon](https://cdn.discordapp.com/app-icons/832012730599735326/3b3981ddf67c8702920fae10b5f123ed.webp?size=80)  | 832012730599735326  | CG2 Staging                      | Unlimited        |
+| ![Icon](https://cdn.discordapp.com/app-icons/832012938398400562/97e50fed67f44802dbb4901d74a6f9a1.webp?size=80)  | 832012938398400562  | CG3 Staging                      | Unlimited        |
+| ![Icon](https://cdn.discordapp.com/app-icons/832025061657280566/832ff736821811d7f41d0ff09b374ccb.webp?size=80)  | 832025061657280566  | CG4 Staging                      | 8                |
+| ![Icon](https://cdn.discordapp.com/app-icons/893449443918086174/74d41d680b96eec08562164988be671a.webp?size=80)  | 893449443918086174  | SpellCast Staging                | 100              |
+| ![Icon](https://cdn.discordapp.com/app-icons/945732077960188005/27881d08b84784b2c98a5aae921c09ae.webp?size=80)  | 945732077960188005  | Putt Party Stg                   | Unlimited        |
+| ![Icon](https://cdn.discordapp.com/app-icons/1049916362383962192/19afbe4b0494b686252b89856a6fe00e.webp?size=80) | 1049916362383962192 | [Deprecated] Colonist.io Staging | Unlimited        |
+| ![Icon](https://cdn.discordapp.com/app-icons/1106787009256767498/19afbe4b0494b686252b89856a6fe00e.webp?size=80) | 1106787009256767498 | Colonist.io Staging              | Unlimited        |
 
 ### QA versions
-| Icon | Application ID | Application name | Nitro? | Max participants |
-|:---:|:---:| --- |:---:|:---:|
-| ![Icon](https://cdn.discordapp.com/app-icons/801133024841957428/b09940bb01c6f0aa2ea4288d5e08218f.webp?size=80) | 801133024841957428 | Poker QA |  | 7 |
-| ![Icon](https://cdn.discordapp.com/app-icons/832012815819604009/3b3981ddf67c8702920fae10b5f123ed.webp?size=80) | 832012815819604009 | CG2 QA |  | Unlimited |
-| ![Icon](https://cdn.discordapp.com/app-icons/832012894068801636/97e50fed67f44802dbb4901d74a6f9a1.webp?size=80) | 832012894068801636 | CG 3 QA |  | Unlimited |
-| ![Icon](https://cdn.discordapp.com/app-icons/832025114077298718/ee2edef3edb605a83e5331de070fd49c.webp?size=80) | 832025114077298718 | CG4 QA |  | 8 |
-| ![Icon](https://cdn.discordapp.com/app-icons/945748195256979606/5f8a388110138fb6fa586eedc73e075a.webp?size=80) | 945748195256979606 | Putt Party QA |  | 8 |
-| ![Icon](https://cdn.discordapp.com/app-icons/1050941315912835122/a380fd3c2d90f436731044cf2c6412e0.webp?size=80) | 1050941315912835122 | Watch Together QA |  | Unlimited |
+| Icon                                                                                                            | Application ID      | Application name  | Max participants |
+|-----------------------------------------------------------------------------------------------------------------|---------------------|-------------------|------------------|
+| ![Icon](https://cdn.discordapp.com/app-icons/801133024841957428/b09940bb01c6f0aa2ea4288d5e08218f.webp?size=80)  | 801133024841957428  | Poker QA          | 7                |
+| ![Icon](https://cdn.discordapp.com/app-icons/832012815819604009/3b3981ddf67c8702920fae10b5f123ed.webp?size=80)  | 832012815819604009  | CG2 QA            | Unlimited        |
+| ![Icon](https://cdn.discordapp.com/app-icons/832012894068801636/97e50fed67f44802dbb4901d74a6f9a1.webp?size=80)  | 832012894068801636  | CG 3 QA           | Unlimited        |
+| ![Icon](https://cdn.discordapp.com/app-icons/832025114077298718/ee2edef3edb605a83e5331de070fd49c.webp?size=80)  | 832025114077298718  | CG4 QA            | 8                |
+| ![Icon](https://cdn.discordapp.com/app-icons/945748195256979606/5f8a388110138fb6fa586eedc73e075a.webp?size=80)  | 945748195256979606  | Putt Party QA     | 8                |
+| ![Icon](https://cdn.discordapp.com/app-icons/1050941315912835122/a380fd3c2d90f436731044cf2c6412e0.webp?size=80) | 1050941315912835122 | Watch Together QA | Unlimited        |
 
 ### Other applications
-| Icon | Application ID | Application name | Nitro? | Max participants |
-|:---:|:---:| --- |:---:|:---:|
-| ❔ | 832025993019260929 | CGSample |  | 100 |
-| ![Icon](https://cdn.discordapp.com/app-icons/880559245471408169/44c30f5fb9ec99753984f50c47524fc9.webp?size=80)| 880559245471408169 | iframe-playground |  | 100 |
-| ❔ | 881732122631634984 | test-game-001 |  | Unlimited |
-| ![Icon](https://cdn.discordapp.com/app-icons/1001529884625088563/ab01dfd5deb4ca7e1649f5e1d2a982aa.webp?size=80)| 1001529884625088563 | Guestbook |  | Unlimited |
-| ❔ | 1100444516957298820 | Chef [PLAYER FEEDBACK] _(Chef Showdown BETATEST)_ |  | Unlimited |
+| Icon                                                                                                            	| Application ID      	| Application name                                  	| Max participants 	|
+|-----------------------------------------------------------------------------------------------------------------	|---------------------	|---------------------------------------------------	|------------------	|
+| ❔                                                                                                               	| 832025993019260929  	| CGSample                                          	| 100              	|
+| ![Icon](https://cdn.discordapp.com/app-icons/880559245471408169/44c30f5fb9ec99753984f50c47524fc9.webp?size=80)  	| 880559245471408169  	| iframe-playground                                 	| 100              	|
+| ❔                                                                                                               	| 881732122631634984  	| test-game-001                                     	| Unlimited        	|
+| ![Icon](https://cdn.discordapp.com/app-icons/1001529884625088563/ab01dfd5deb4ca7e1649f5e1d2a982aa.webp?size=80) 	| 1001529884625088563 	| Guestbook                                         	| Unlimited        	|
+| ❔                                                                                                               	| 1100444516957298820 	| Chef [PLAYER FEEDBACK] _(Chef Showdown BETATEST)_ 	| Unlimited        	|
 
 ### Deleted applications
-| Icon | Application ID | Application name | Nitro? | Max participants |
-|:---:|:---:| --- |:---:|:---:|
-| ❔ | 832012854282158180 | Delete Me Calla _(Formerly known as 'putt dis' 'click dis' and 'Putts'.)_ |  | 12 |
-| ❔ | 832025179659960360 | Discord Game 14 |
-| ❔ | 832025219526033439 | Discord Game 15 |
-| ❔ | 832025249335738428 | Discord Game 16 |
-| ❔ | 832025333930524692 | Discord Game 17 |
-| ❔ | 832025385159622656 | Discord Game 18 |
-| ❔ | 832025431280320532 | Discord Game 19 |
-| ❔ | 832025470685937707 | Discord Game 20 |
-| ❔ | 832025799590281238 | Discord Game 21 |
-| ❔ | 832025857525678142 | Discord Game 22 |  | Unlimited |
-| ❔ | 832025886030168105 | Discord Game 23 |  | Unlimited |
-| ❔ | 832025928938946590 | Discord Game 24 |  | 100 |
-| ![Icon](https://cdn.discordapp.com/app-icons/878067389634314250/9bd4b9e21576f14f09a9284d45640a9e.webp?size=80) | 878067389634314250 | Doodle Crew _(Deprecated. Replaced by 'Sketch Heads')_ |  | 16 |
-| ![Icon](https://cdn.discordapp.com/app-icons/878067427668275241/50be5b98e871a395aa160fefdba5b596.webp?size=80) | 878067427668275241 | Doodle Crew Dev _(Deprecated. Replaced by 'Sketch Heads Dev')_ |  | 16 |
-| ![Icon](https://cdn.discordapp.com/app-icons/879863881349087252/7bb9cd8518723b74c9a1d260cd177f24.webp?size=80) | 879863881349087252 | Awkword |  | 12 |
-| ![Icon](https://cdn.discordapp.com/app-icons/879863923543785532/dfd06404877f7bb863430d32c43480fd.webp?size=80) | 879863923543785532 | Awkword Dev |  | 32 |
-| ![Icon](https://cdn.discordapp.com/app-icons/879863976006127627/930f9cfe504211a130419e731babc597.webp?size=80) | 879863976006127627 | Word Snacks |  | 8 |
-| ![Icon](https://cdn.discordapp.com/app-icons/879864010126786570/1e47e5a033aa7a853fdea22534292bfe.webp?size=80) | 879864010126786570 | Word Snacks Dev |  | 32 |
-| ![Icon](https://cdn.discordapp.com/app-icons/879864070101172255/0214576f3c33e4026a72f248c11d2292.webp?size=80) | 879864070101172255 | Sketchy Artist |  | 12 |
-| ![Icon](https://cdn.discordapp.com/app-icons/879864104980979792/86df8c0d2ab678bba9ac560d42a6f9aa.webp?size=80) | 879864104980979792 | Sketchy Artist Dev |  | 12 |
-| ![Icon](https://cdn.discordapp.com/app-icons/891001866073296967/ab9c4e0add01dc8934a336bbc947738e.webp?size=80) | 891001866073296967 | Decoders Dev |  | 32 |
-| ❔ | 1006986333539029022 | Clone - Watch Together |  | Unlimited |
+| Icon                                                                                                           	  | Application ID      	| Application name                                                          	| Max participants 	|
+|----------------------------------------------------------------------------------------------------------------	  |---------------------	|---------------------------------------------------------------------------	|------------------	|
+| ❔                                                                                                              	| 832012854282158180  	| Delete Me Calla _(Formerly known as 'putt dis' 'click dis' and 'Putts'.)_ 	| 12               	|
+| ❔                                                                                                              	| 832025179659960360  	| Discord Game 14                                                           	|                  	|
+| ❔                                                                                                              	| 832025219526033439  	| Discord Game 15                                                           	|                  	|
+| ❔                                                                                                              	| 832025249335738428  	| Discord Game 16                                                           	|                  	|
+| ❔                                                                                                              	| 832025333930524692  	| Discord Game 17                                                           	|                  	|
+| ❔                                                                                                              	| 832025385159622656  	| Discord Game 18                                                           	|                  	|
+| ❔                                                                                                              	| 832025431280320532  	| Discord Game 19                                                           	|                  	|
+| ❔                                                                                                              	| 832025470685937707  	| Discord Game 20                                                           	|                  	|
+| ❔                                                                                                              	| 832025799590281238  	| Discord Game 21                                                           	|                  	|
+| ❔                                                                                                              	| 832025857525678142  	| Discord Game 22                                                           	| Unlimited        	|
+| ❔                                                                                                              	| 832025886030168105  	| Discord Game 23                                                           	| Unlimited        	|
+| ❔                                                                                                              	| 832025928938946590  	| Discord Game 24                                                           	| 100              	|
+| ![Icon](https://cdn.discordapp.com/app-icons/878067389634314250/9bd4b9e21576f14f09a9284d45640a9e.webp?size=80) 	  | 878067389634314250  	| Doodle Crew _(Deprecated. Replaced by 'Sketch Heads')_                    	| 16               	|
+| ![Icon](https://cdn.discordapp.com/app-icons/878067427668275241/50be5b98e871a395aa160fefdba5b596.webp?size=80) 	  | 878067427668275241  	| Doodle Crew Dev _(Deprecated. Replaced by 'Sketch Heads Dev')_            	| 16               	|
+| ![Icon](https://cdn.discordapp.com/app-icons/879863881349087252/7bb9cd8518723b74c9a1d260cd177f24.webp?size=80) 	  | 879863881349087252  	| Awkword                                                                   	| 12               	|
+| ![Icon](https://cdn.discordapp.com/app-icons/879863923543785532/dfd06404877f7bb863430d32c43480fd.webp?size=80) 	  | 879863923543785532  	| Awkword Dev                                                               	| 32               	|
+| ![Icon](https://cdn.discordapp.com/app-icons/879863976006127627/930f9cfe504211a130419e731babc597.webp?size=80) 	  | 879863976006127627  	| Word Snacks                                                               	| 8                	|
+| ![Icon](https://cdn.discordapp.com/app-icons/879864010126786570/1e47e5a033aa7a853fdea22534292bfe.webp?size=80) 	  | 879864010126786570  	| Word Snacks Dev                                                           	| 32               	|
+| ![Icon](https://cdn.discordapp.com/app-icons/879864070101172255/0214576f3c33e4026a72f248c11d2292.webp?size=80) 	  | 879864070101172255  	| Sketchy Artist                                                            	| 12               	|
+| ![Icon](https://cdn.discordapp.com/app-icons/879864104980979792/86df8c0d2ab678bba9ac560d42a6f9aa.webp?size=80) 	  | 879864104980979792  	| Sketchy Artist Dev                                                        	| 12               	|
+| ![Icon](https://cdn.discordapp.com/app-icons/891001866073296967/ab9c4e0add01dc8934a336bbc947738e.webp?size=80) 	  | 891001866073296967  	| Decoders Dev                                                              	| 32               	|
+| ❔                                                                                                              	| 1006986333539029022 	| Clone - Watch Together                                                    	| Unlimited        	|
 
 ## MAX CONCURRENT ACTIVITIES
 | Boost tier | Max concurrent activities |


### PR DESCRIPTION
Selected activities will no longer be exclusive to Discord Nitro subscribers. Today, during the working day, the discord team posted information in the application code that post-birthday activities will be a non-nitro function forever (previously, a form was prepared that examined the impact of activities on discord and its users)

Sources:
- Experiment - [Experiment obj from API](https://sourcegraph.com/github.com/xHyroM/discord-datamining@53cd11cd700213496622c7a130e1e311e340ebaa/-/blob/data/client/experiments/experiments/2205929113/data.json) 
- Screenshot - [Tweet](https://twitter.com/WumpusCentral/status/1668866784118669313)