### PR TITLE
Removed backyard.co domain

### DIFF
--- a/domains.md
+++ b/domains.md
@@ -24,7 +24,6 @@
 | discordsays.com       | Voice channel activity host              |
 | discordsez.com        | Voice channel activity staging host      |
 | discordstatus.com     | Status page                              |
-| backyard.co           | Voice channel activity API host          |
 
 ## Other
 


### PR DESCRIPTION
This domain no longer belongs to Discord. This domain has been newly registered (after it was added here via #261) and is now for sale via AfterNic.


Whois: https://www.whois.com/whois/backyard.co

![image](https://github.com/Delitefully/DiscordLists/assets/42101045/0dcc77ab-1d9b-4552-9423-f6754c9abca4)
