### PR TITLE
Add Dave protocol

### DIFF
--- a/domains.md
+++ b/domains.md
@@ -32,6 +32,7 @@
 | airhorn.solutions         | [API implementation example](https://github.com/discord/airhornbot) |
 | airhornbot.com            | ^                                                                   |
 | bigbeans.solutions        | [April Fools 2017](https://youtu.be/9Z4GW6Vd6NI)                    |
+| daveprotocol.com          | Discord's Audio & Video End-to-End Encryption (DAVE) protocol       |
 | watchanimeattheoffice.com | HypeSquad form placeholder/meme                                     |
 
 ## Unused


### PR DESCRIPTION
Newly registered domain: https://www.whois.com/whois/daveprotocol.com
Linked on https://github.com/discord/libdave
Linked on https://github.com/discord/dave-protocol as well